### PR TITLE
Fix the curl command option of -C

### DIFF
--- a/biligrab.py
+++ b/biligrab.py
@@ -265,7 +265,7 @@ def download_video_link((part_number, download_software, video_link, thread_sing
     elif download_software == 'wget':
         cmd = 'wget -c -A "{FAKE_UA}" -O {part_number}.flv "{video_link}"'
     elif download_software == 'curl':
-        cmd = 'curl -L -C -A "{FAKE_UA}" -o {part_number}.flv "{video_link}"'
+        cmd = 'curl -L -C - -A "{FAKE_UA}" -o {part_number}.flv "{video_link}"'
     elif download_software == 'axel':
         cmd = 'axel -U "{FAKE_UA}" -n {thread_single_download} -o {part_number}.flv "{video_link}"'
     cmd = cmd.format(part_number = part_number, video_link = video_link, thread_single_download = thread_single_download, FAKE_UA = FAKE_UA)


### PR DESCRIPTION
The manual of `curl` says

```
-C, --continue-at <offset>
              Continue/Resume  a  previous  file transfer at the given offset. The given offset is the exact number of bytes that will be skipped, counting from the beginning of the
              source file before it is transferred to the destination.  If used with uploads, the FTP server command SIZE will not be used by curl.

              Use "-C -" to tell curl to automatically find out where/how to resume the transfer. It then uses the given output/input files to figure that out.
```

The original version does not specify an offset to continue at and results in errors when `curl` is the downloader in use.